### PR TITLE
Removed deprecated endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ _Warning: without these headers, the request will fail._
 - **[<code>GET</code> v1/students/_{studentId}_/cards]()**
 ##### Grades
 - **[<code>GET</code> v1/students/_{studentId}_/grades]()**
-- **[<code>GET</code> v1/students/_{studentId}_/grades/subject/_{subject}_]()**
 ##### Lessons
 - **[<code>GET</code> v1/students/_{studentId}_/lessons/today]()**
 - **[<code>GET</code> v1/students/_{studentId}_/lessons/_{day}_]()**


### PR DESCRIPTION
Removed <code>v1/students/{studentId}/grades/subject/{subject}</code> (deprecated)
This endpoint was no longer found in the classeviva studenti decompiled apk, and always returns HTTP error 404